### PR TITLE
Move cert_name parameter default to module data

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,3 +22,5 @@ icinga::agent::logging_level: warning
 icinga::agentless::user: icinga
 icinga::agentless::manage_user: true
 icinga::agentless::ssh_key_type: rsa
+
+icinga::cert_name: "%{facts.networking.fqdn}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class icinga (
   Boolean                                 $ca,
   String                                  $this_zone,
   Hash[String, Hash]                      $zones,
+  String                                  $cert_name,
   Optional[Stdlib::Host]                  $ca_server       = undef,
   Optional[Icinga::Secret]                $ticket_salt     = undef,
   Array[String]                           $extra_packages  = [],
@@ -57,7 +58,6 @@ class icinga (
   Optional[Icinga::LogLevel]              $logging_level   = undef,
   Optional[Icinga::Secret]                $ssh_private_key = undef,
   Optional[Enum['ecdsa','ed25519','rsa']] $ssh_key_type    = undef,
-  String                                  $cert_name       = $facts['networking']['fqdn'],
   Boolean                                 $prepare_web     = false,
   Variant[Boolean, String]                $confd           = false,
 ) {


### PR DESCRIPTION
So we can use the default via lookup directly in hiera, e.g. for host object names.