### PR TITLE
Fix private key permissions

### DIFF
--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -24,7 +24,7 @@ define icinga::cert (
       group => $group,
       mode  => '0640',
     }
-    $key_mode = '0400'
+    $key_mode = '0440'
   }
 
   if $args[key] {

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -43,7 +43,7 @@ describe('icinga::cert', type: :define) do
             {
               'owner' => 'foo',
               'group' => 'bar',
-              'mode'  => '0400',
+              'mode'  => '0440',
             }
           ).with_content('key')
         }


### PR DESCRIPTION
Some modules requires running daemons under a different user, but also belong to group icingaweb2. So the private keys for database auth need read permission.