### PR TITLE
Replace service command usage to restart icinga service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,8 +188,8 @@ class icinga (
 
         ~> exec { 'restarting icinga2':
           path        => $facts['path'],
-          command     => "service ${icinga_service} restart",
-          onlyif      => "service ${icinga_service} status",
+          command     => "systemctl restart ${icinga_service}",
+          onlyif      => "systemctl status ${icinga_service}",
           refreshonly => true,
         }
       } # prepare_web


### PR DESCRIPTION
Compatibility is no longer required, so the dependency on the initscript-service package (e.g. on EL platform) can also be omitted.